### PR TITLE
Allow TensorFlow 2.13+ for Python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ tqdm>=4.62.0
 
 # SLEAP and ML dependencies
 sleap>=1.3.0
-tensorflow>=2.7.0,<2.13.0
+tensorflow>=2.13.0
 opencv-python>=4.5.0,<4.8.0
 scikit-learn>=1.0.0,<1.3.0
 h5py>=3.6.0,<3.10.0


### PR DESCRIPTION
## Summary
- permit TensorFlow 2.13+ in requirements to support Python 3.11 installations

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
import tensorflow as tf
print('TensorFlow version:', tf.__version__)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c1b0a9190c832895de89450c39f635