### PR TITLE
Add SLEAP and TensorFlow to installer requirements

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -121,6 +121,8 @@ EOF
     # Crear requirements.txt
     cat > requirements.txt << 'EOF'
 # Core dependencies
+sleap>=1.3.0
+tensorflow>=2.7.0,<2.13.0
 tkinter-tooltip==2.1.0
 pillow>=9.0.0
 numpy>=1.21.0


### PR DESCRIPTION
## Summary
- Include sleap and tensorflow packages in generated requirements list

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68c1b0a9e5e88328a9082dd73b16c81f