### PR TITLE
Add cross-platform installer launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # CinBehave
+
+Herramienta de análisis de comportamiento con integración de SLEAP.
+
+## Instalación rápida
+
+1. Descarga o clona este repositorio.
+2. Ejecuta (doble clic) el archivo `install.py`.
+   - En Windows ejecutará `install_windows.bat`.
+   - En sistemas basados en Unix ejecutará `install.sh`.
+3. Sigue las instrucciones en pantalla para completar la instalación.
+4. Al finalizar, verás el mensaje "Installation completed successfully.".
+   Para comprobarlo, ejecuta `python cinbehave_gui.py` y verifica que la interfaz se abre.
+
+Los scripts específicos de la plataforma siguen siendo los responsables de
+instalar dependencias, crear entornos virtuales y preparar la aplicación.
+`install.py` solo actúa como lanzador cómodo para usuarios que prefieren un
+paso único de instalación.

--- a/install.py
+++ b/install.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Simple cross-platform installer launcher for CinBehave.
+
+This script detects the operating system and executes the corresponding
+installation script so that users can simply double-click this file after
+downloading the project. The existing platform-specific scripts remain
+responsible for performing the actual setup steps.
+"""
+import os
+import platform
+import subprocess
+import sys
+
+
+def main() -> None:
+    """Run the appropriate installer for the current platform."""
+    repo_root = os.path.dirname(os.path.abspath(__file__))
+    system = platform.system()
+
+    try:
+        if system == "Windows":
+            script = os.path.join(repo_root, "install_windows.bat")
+            if not os.path.exists(script):
+                print("Missing 'install_windows.bat' in repository root.")
+                sys.exit(1)
+            # Execute the batch file through cmd
+            subprocess.run(["cmd", "/c", script], check=True)
+        else:
+            script = os.path.join(repo_root, "install.sh")
+            if not os.path.exists(script):
+                print("Missing 'install.sh' in repository root.")
+                sys.exit(1)
+            # Use bash to execute shell script
+            subprocess.run(["bash", script], check=True)
+
+        print("Installation completed successfully.")
+        print("Run 'python cinbehave_gui.py' to verify the installation.")
+    except subprocess.CalledProcessError as exc:
+        # Propagate the exit code from the installer script
+        print(f"Installer failed with exit code {exc.returncode}.")
+        sys.exit(exc.returncode)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `install.py` wrapper to automatically run OS-specific installer scripts
- document quick installation steps in README
- print success message and explain how to verify installation

## Testing
- `python -m py_compile install.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1c6d6654883289c7d79061d19becf