### PR TITLE
Escape parentheses in Windows Installer retry prompt

### DIFF
--- a/install_windows.bat
+++ b/install_windows.bat
@@ -79,7 +79,7 @@ sc query msiserver | findstr /I "RUNNING" >nul
 if errorlevel 1 (
     echo [ERROR] El servicio Windows Installer (msiserver) no esta activo.
     echo [INFO] Para iniciarlo manualmente, ejecute: net start msiserver
-    set /p "RETRY=¿Reintentar verificacion tras iniciarlo? (s/n): "
+    set /p "RETRY=¿Reintentar verificacion tras iniciarlo? ^(s/n^): "
     if /i "!RETRY!"=="s" goto check_msiserver
     echo [INFO] Instalacion cancelada hasta que el servicio este activo.
     pause


### PR DESCRIPTION
## Summary
- Escape parentheses in Windows Installer service check retry prompt so the characters are treated literally

## Testing
- `bash install_windows.bat` *(fails: windows commands not available)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bee8c5e883288e795d7441870f82